### PR TITLE
feat: set probability to campaigns along with a fallback property

### DIFF
--- a/campaigns.go
+++ b/campaigns.go
@@ -19,6 +19,8 @@ type CampaignAd struct {
 	Id          string
 	Placeholder string
 	Ratio       float32
+	Probability float32
+	Fallback    bool
 }
 
 type ScheduledCampaignAd struct {
@@ -30,7 +32,7 @@ type ScheduledCampaignAd struct {
 var addCampaign = func(ctx context.Context, camp ScheduledCampaignAd) error {
 	return hystrix.DoC(ctx, hystrixDb,
 		func(ctx context.Context) error {
-			_, err := addCampStmt.ExecContext(ctx, camp.Id, camp.Description, camp.Link, camp.Image, camp.Ratio, camp.Placeholder, camp.Source, camp.Start, camp.End)
+			_, err := addCampStmt.ExecContext(ctx, camp.Id, camp.Description, camp.Link, camp.Image, camp.Ratio, camp.Placeholder, camp.Source, camp.Company, camp.Probability, camp.Fallback, camp.Start, camp.End)
 			if err != nil {
 				return err
 			}
@@ -52,11 +54,10 @@ var fetchCampaigns = func(ctx context.Context, timestamp time.Time) ([]CampaignA
 			var res []CampaignAd
 			for rows.Next() {
 				var camp CampaignAd
-				err := rows.Scan(&camp.Id, &camp.Description, &camp.Link, &camp.Image, &camp.Ratio, &camp.Placeholder, &camp.Source)
+				err := rows.Scan(&camp.Id, &camp.Description, &camp.Link, &camp.Image, &camp.Ratio, &camp.Placeholder, &camp.Source, &camp.Company, &camp.Probability, &camp.Fallback)
 				if err != nil {
 					return err
 				}
-				camp.Company = camp.Source
 				res = append(res, camp)
 			}
 			err = rows.Err()

--- a/campaigns_test.go
+++ b/campaigns_test.go
@@ -11,12 +11,14 @@ var camp = CampaignAd{
 	Placeholder: "placholder",
 	Ratio:       0.5,
 	Id:          "id",
+	Probability: 1,
+	Fallback:    true,
 	Ad: Ad{
 		Source:      "source",
 		Image:       "image",
 		Link:        "http://link.com",
 		Description: "desc",
-		Company:     "source",
+		Company:     "company",
 	},
 }
 

--- a/db.go
+++ b/db.go
@@ -13,7 +13,7 @@ import (
 )
 
 var dbConnString = os.Getenv("DB_CONNECTION_STRING")
-var migrationVer uint = 1
+var migrationVer uint = 2
 var db *sql.DB
 var hystrixDb = "db"
 var campStmt *sql.Stmt
@@ -70,7 +70,8 @@ func initializeDatabase() {
 	}
 
 	campStmt, err = db.Prepare(
-		"select `id`, `title`, `url`, `image`, `ratio`, `placeholder`, `source`" +
+		"select `id`, `title`, `url`, `image`, `ratio`, `placeholder`, " +
+			"`source`, `company`, `probability`, `fallback`" +
 			"from `ads` where `start` <= ? and end > ?")
 	if err != nil {
 		log.Fatal("failed to prepare query ", err)
@@ -78,8 +79,9 @@ func initializeDatabase() {
 
 	addCampStmt, err = db.Prepare(
 		"insert into `ads` " +
-			"(`id`, `title`, `url`, `image`, `ratio`, `placeholder`, `source`, `start`, `end`) " +
-			"values (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			"(`id`, `title`, `url`, `image`, `ratio`, `placeholder`, `source`, " +
+			"`company`, `probability`, `fallback`, `start`, `end`) " +
+			"values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Fatal("failed to prepare query ", err)
 	}

--- a/migrations/2_probability.down.sql
+++ b/migrations/2_probability.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `ads` DROP COLUMN `probability`, `fallback`, `company`;

--- a/migrations/2_probability.up.sql
+++ b/migrations/2_probability.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `ads`
+    ADD COLUMN `probability` FLOAT(8,2) DEFAULT 0.0,
+    ADD COLUMN `fallback` TINYINT DEFAULT 0,
+    ADD COLUMN `company` varchar(255) CHARACTER SET utf8mb4;


### PR DESCRIPTION
Now campaigns can be set as fallback ads. Fallback campaigns are available only in case no other channel has provided an ad for the request.
Also, a probability is set for each campaign to support use cases where more than one self-service campaign is running.